### PR TITLE
Fix New Republic and Scientific American recipes

### DIFF
--- a/recipes/new-republic-magazine.recipe.py
+++ b/recipes/new-republic-magazine.recipe.py
@@ -148,8 +148,6 @@ fragment ArticlePageFields on Article {
   galleries {
     id
     galleryData {
-      captionText
-      creditText
       image {
         id
         src

--- a/recipes/scientific-american.recipe.py
+++ b/recipes/scientific-american.recipe.py
@@ -11,9 +11,9 @@ from urllib.parse import urljoin
 
 # custom include to share code between recipes
 sys.path.append(os.environ["recipes_includes"])
-from recipes_shared import BasicNewsrackRecipe
+from recipes_shared import BasicNewsrackRecipe, parse_date
 
-from calibre.web.feeds.news import BasicNewsRecipe
+from calibre.web.feeds.news import BasicNewsRecipe, prefixed_classes
 
 
 _name = "Scientific American"
@@ -37,15 +37,8 @@ class ScientificAmerican(BasicNewsrackRecipe, BasicNewsRecipe):
 
     remove_attributes = ["width", "height"]
     keep_only_tags = [
-        dict(
-            class_=[
-                "feature-article--header-title",
-                "article-header",
-                "article-content",
-                "article-media",
-                "article-author",
-                "article-text",
-            ]
+        prefixed_classes(
+            'article_hed- article_dek- article_authors- lead_image- article__content- bio-'
         ),
     ]
     remove_tags = [
@@ -63,11 +56,11 @@ class ScientificAmerican(BasicNewsrackRecipe, BasicNewsRecipe):
     ]
 
     extra_css = """
-    h1[itemprop="headline"] { font-size: 1.8rem; margin-bottom: 0.4rem; }
-    p.t_article-subtitle { font-size: 1.2rem; font-style: italic; margin-bottom: 1rem; }
-    .meta-list { padding-left: 0; margin-bottom: 1rem; }
-    .article-media img, .image-captioned img { max-width: 100%; height: auto; }
-    .image-captioned div, .t_caption { font-size: 0.8rem; margin-top: 0.2rem; margin-bottom: 0.5rem; }
+    h1[class^="article_hed-"] { font-size: 1.8rem; margin-bottom: 0.4rem; }
+    [class^="article_dek-"] p { font-size: 1.2rem; font-style: italic; margin-bottom: 1rem; }
+    [class^="article_authors-"] { padding-left: 0; margin-bottom: 1rem; }
+    [class^="lead_image-"] img, [class^="article_image-"] img, [class^="article__image-"] img { max-width: 100%; height: auto; }
+    div[class^="lead_image__figcaption"], .t_caption { font-size: 0.8rem; margin-top: 0.2rem; margin-bottom: 0.5rem; }
     """
 
     def get_browser(self, *a, **kw):
@@ -79,13 +72,9 @@ class ScientificAmerican(BasicNewsrackRecipe, BasicNewsRecipe):
 
     def preprocess_raw_html(self, raw_html, url):
         soup = self.soup(raw_html)
-        info = self.get_script_json(soup, r"dataLayer\s*=\s*")
+        info = self.get_ld_json(soup, lambda d: d.get("dateModified"))
         if info:
-            for i in info:
-                if not i.get("content"):
-                    continue
-                content = i["content"]
-                soup.find("h1")["published_at"] = content["contentInfo"]["publishedAt"]
+            soup.find("h1")["published_at"] = info["datePublished"]
 
         # shift article media to after heading
         article_media = soup.find(class_="article-media")
@@ -103,9 +92,7 @@ class ScientificAmerican(BasicNewsrackRecipe, BasicNewsRecipe):
     def populate_article_metadata(self, article, soup, first):
         published_ele = soup.find(attrs={"published_at": True})
         if published_ele:
-            pub_date = datetime.utcfromtimestamp(
-                int(published_ele["published_at"])
-            ).replace(tzinfo=timezone.utc)
+            pub_date = parse_date(published_ele["published_at"], tz_info=timezone.utc)
             article.utctime = pub_date
 
             # pub date is always 1st of the coming month

--- a/recipes/scientific-american.recipe.py
+++ b/recipes/scientific-american.recipe.py
@@ -53,6 +53,7 @@ class ScientificAmerican(BasicNewsrackRecipe, BasicNewsRecipe):
                 "article-date-published",
             ]
         ),
+        prefixed_classes('breakoutContainer- readThisNext- newsletterSignup-')
     ]
 
     extra_css = """


### PR DESCRIPTION
### Explanation for New Republic

The New Republic recipe started showing HTTP 400 errors when attempting to download any article endpoints.

When an endpoint URI was input into a browser, the server gave this error message:

```json
{"errors":[{"message":"Cannot query field \"captionText\" on type \"GalleryData\".","locations":[{"line":71,"column":7}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"Cannot query field \"creditText\" on type \"GalleryData\".","locations":[{"line":72,"column":7}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}
```

If I am understanding the error correctly, the New Republic recipe has fields in the query that don't appear to exist in the news site's database.

This pull request will remove the specific fields named in the above error message from the recipe's query, which enables the recipe to fetch articles again.

### Explanation for Scientific American

Scientific American has changed its CSS classes. This pull request updates the ```keep_only_tags``` and ```extra_css``` accordingly, and updates the recipe to find each article's script ld+json element.